### PR TITLE
carregar menu após de inicializar página

### DIFF
--- a/src/pages/location.html
+++ b/src/pages/location.html
@@ -9,8 +9,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
 
-    <script src="../scripts/fittext.js"></script>
-
     <link rel="manifest" href="/manifest.json">
 
     <link rel="stylesheet" href="../styles/css/general.css" />
@@ -59,10 +57,5 @@
     </div>
 
 </body>
-<script>
-    window.fitText(document.getElementsByClassName('button'), 1.5);
-    window.fitText(document.getElementsByClassName('h1'), 0.55);
-    window.fitText(document.getElementsByClassName('h2'), 1);
-</script>
 
 </html>

--- a/src/scripts/components/menu.js
+++ b/src/scripts/components/menu.js
@@ -1,13 +1,12 @@
-//Esse método carrega o arquivo html como string e inicializa o menu depois de carregado
-//Fica mais fácil pra editar o menu diretamente do .html
+//carrega o arquivo html como string e inicializa o menu depois de carregado
 export function loadMenuComponent(){
     $.get("../pages/components/menu.html", function(html_string)
     {
-        inicializeMenu(html_string); 
+        initializeMenu(html_string); 
     },'html');
 }
 
-function inicializeMenu(htmlContent) {
+function initializeMenu(htmlContent) {
         const divElement = document.getElementById('menu');
 
         divElement.innerHTML = htmlContent;
@@ -37,36 +36,40 @@ function inicializeMenu(htmlContent) {
 }
 
 
-//maneira gambiarrosa mas que funciona por enquanto
 function updateMenuActiveButton(){
     const searchButton = document.querySelector('#bottom-tab > .products > button');
     const favoritesButton = document.querySelector('#bottom-tab > .favorites > button');
     const storesButton = document.querySelector('#bottom-tab > .stores > button');
 
-    //pega o nome do arquivo da página carregada no momento
     //var fileName = location.href.split("/").slice(-1);
     var lastPage = localStorage.getItem("lastPage") ? localStorage.getItem("lastPage") : location.href;
-    var path = lastPage.substring(lastPage.lastIndexOf("/")+ 1);    
+    var path = lastPage.substring(lastPage.lastIndexOf("/")+ 1);
     var fileName = (path.match(/[^.]+(\.[^?#]+)?/) || [])[0];
-    //e compara via hardcode
+
+    console.log(fileName);
+
     if(lastPage.includes("?market=") || fileName == "stores.html"){
         searchButton.className = "disabled";
         favoritesButton.className = "disabled";
         storesButton.className = "";
+        console.log("MENU > ESTABALECIMENTOS");
     }
     else if(fileName == "search_products.html" || fileName == "product.html"){
         searchButton.className = "";
         favoritesButton.className = "disabled";
-        storesButton.className = "disabled";    
+        storesButton.className = "disabled";
+        console.log("MENU > SEARCH");  
     }
     else if(fileName == "favorites.html"){
         searchButton.className = "disabled";
         favoritesButton.className = "";
         storesButton.className = "disabled";  
+        console.log("MENU > FAVORITES");
     }
     else{        
         searchButton.className = "disabled";
         favoritesButton.className = "disabled";
         storesButton.className = "disabled";
+        console.log("MENU > NOTHING");
     }
 }

--- a/src/scripts/components/menu.js
+++ b/src/scripts/components/menu.js
@@ -1,13 +1,12 @@
-//Esse método carrega o arquivo html como string e inicializa o menu depois de carregado
-//Fica mais fácil pra editar o menu diretamente do .html
+//carrega o arquivo html como string e inicializa o menu depois de carregado
 export function loadMenuComponent(){
     $.get("../pages/components/menu.html", function(html_string)
     {
-        inicializeMenu(html_string); 
+        initializeMenu(html_string); 
     },'html');
 }
 
-function inicializeMenu(htmlContent) {
+function initializeMenu(htmlContent) {
         const divElement = document.getElementById('menu');
 
         divElement.innerHTML = htmlContent;
@@ -37,18 +36,16 @@ function inicializeMenu(htmlContent) {
 }
 
 
-//maneira gambiarrosa mas que funciona por enquanto
 function updateMenuActiveButton(){
     const searchButton = document.querySelector('#bottom-tab > .products > button');
     const favoritesButton = document.querySelector('#bottom-tab > .favorites > button');
     const storesButton = document.querySelector('#bottom-tab > .stores > button');
 
-    //pega o nome do arquivo da página carregada no momento
     //var fileName = location.href.split("/").slice(-1);
     var lastPage = localStorage.getItem("lastPage") ? localStorage.getItem("lastPage") : location.href;
-    var path = lastPage.substring(lastPage.lastIndexOf("/")+ 1);    
+    var path = lastPage.substring(lastPage.lastIndexOf("/")+ 1);
     var fileName = (path.match(/[^.]+(\.[^?#]+)?/) || [])[0];
-    //e compara via hardcode
+
     if(lastPage.includes("?market=") || fileName == "stores.html"){
         searchButton.className = "disabled";
         favoritesButton.className = "disabled";

--- a/src/scripts/components/search.js
+++ b/src/scripts/components/search.js
@@ -1,6 +1,6 @@
 import { fetchData } from "../fetchData.js";
-import { loadMenuComponent } from "../components/menu.js";
 import { until } from "../asyncUtils.js";
+import { loadMenuComponent } from "../components/menu.js";
 const urlParams = new URLSearchParams(window.location.search);
 
 const instruction = document.querySelector('#resultado > .instruction');
@@ -57,6 +57,8 @@ function initializePage(){
     }
 
     localStorage.setItem("lastPage", window.location.href);
+
+    loadMenuComponent();
 }
 
 async function restoreLastSearch(){
@@ -71,8 +73,6 @@ async function restoreLastSearch(){
 }
 
 initializePage();
-loadMenuComponent();
-//inicializeMenu();
 
 function clearProductContainer() {
     while (lista.firstChild) {

--- a/src/scripts/favorites.js
+++ b/src/scripts/favorites.js
@@ -24,7 +24,6 @@ const favButtonInnerHtml=`
 
 const lista = document.getElementById("lista");
 const emptyArea = document.getElementById("empty-list-area");
-loadMenuComponent();
 
 // (async () => {
 //     if (JSON.parse(localStorage.getItem("favorites")).length === 0 || !localStorage.getItem("favorites")) {
@@ -69,6 +68,8 @@ async function initializePage(){
 
     //save last page
     localStorage.setItem("lastPage", window.location.href);
+
+    loadMenuComponent();
 }
 
 function spawnFavoritesList(favoritesList){

--- a/src/scripts/favorites.js
+++ b/src/scripts/favorites.js
@@ -24,7 +24,6 @@ const favButtonInnerHtml=`
 
 const lista = document.getElementById("lista");
 const emptyArea = document.getElementById("empty-list-area");
-loadMenuComponent();
 
 // (async () => {
 //     if (JSON.parse(localStorage.getItem("favorites")).length === 0 || !localStorage.getItem("favorites")) {
@@ -49,6 +48,8 @@ loadMenuComponent();
 
 
 initializePage();
+
+loadMenuComponent();
 
 async function initializePage(){
     lista.innerHTML = "";

--- a/src/scripts/product.js
+++ b/src/scripts/product.js
@@ -11,8 +11,6 @@ const topHeader = document.getElementById("top-header");
 const backButton = document.getElementById("back-button");
 const lista = document.getElementById("lista");
 
-loadMenuComponent();
-
 favoriteButton.addEventListener("click", handleFavorite);
 backButton.addEventListener("click", backButtonClick);
 
@@ -57,6 +55,8 @@ var marketCoords;
   document.title = product[0].name;
 
   getRelatedProduts();
+
+  loadMenuComponent();
 })();
 
 async function getRelatedProduts() {

--- a/src/scripts/stores.js
+++ b/src/scripts/stores.js
@@ -14,11 +14,12 @@ const gpsSvg =`
 `;
 
 const lista = document.getElementById("lista");
-loadMenuComponent();
 
 var marketCoords;
 
 initializePage();
+
+loadMenuComponent();
 
 async function initializePage(){
     lista.innerHTML = "";

--- a/src/scripts/stores.js
+++ b/src/scripts/stores.js
@@ -14,7 +14,6 @@ const gpsSvg =`
 `;
 
 const lista = document.getElementById("lista");
-loadMenuComponent();
 
 var marketCoords;
 
@@ -32,6 +31,8 @@ async function initializePage(){
 
     //save last page
     localStorage.setItem("lastPage", window.location.href);
+
+    loadMenuComponent();
 }
 
 function getStoreListFromData(data){

--- a/src/styles/css/location.css
+++ b/src/styles/css/location.css
@@ -50,8 +50,10 @@ dialog {
         font-family: 'Encode Sans';
         font-style: normal;
         font-weight: 700;
-        font-size: 4vh;
-        line-height:4vh;
+        /* font-size: 4vh; */
+        font-size: clamp(7vw, 4vh, 9vw);
+        /* line-height: 4vh; */
+        line-height: clamp(7vw, 4vh, 9vw); 
 
         color: #FFFFFF;
 
@@ -60,7 +62,8 @@ dialog {
 .h1{
         font-family: 'Encode Sans';
         font-weight: 800;
-        font-size: 6vh;
+        /* font-size: 6vh;   */
+        font-size: clamp(10vw, 6.5vh, 14vw); 
         
         /* background: linear-gradient(#DE80AE, #DE80AE); */
         background: linear-gradient(330deg, #56ffc7, #29ff70);
@@ -91,7 +94,7 @@ dialog {
         border: 0.1vh solid #4CD964;
         border-radius: 50px;
         padding: 1.5vh 10px;
-        width: 80%;
+        width: 82vw;
         margin: 0 auto;
 
         color: white;
@@ -103,7 +106,8 @@ dialog {
         font-family: 'Encode Sans';
         font-style: normal;
         font-weight: 700;
-        font-size: 2.5vh;
+        /* font-size: 2.5vh; */
+        font-size: clamp(0.5vw, 2.5vh, 5vw);
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
Mudança na ordem de carregamento do menu para possivelmente prevenir bug que impede o menu atualizar a aba ativa ao mudar entre a aba "buscar produtos" e "estabelecimentos".